### PR TITLE
added support for distros where libs are called .so.0

### DIFF
--- a/hid/__init__.py
+++ b/hid/__init__.py
@@ -7,12 +7,21 @@ try:
     hidapi = ctypes.cdll.LoadLibrary('libhidapi-hidraw.so')
 except OSError:
     try:
-        hidapi = ctypes.cdll.LoadLibrary('libhidapi-libusb.so')
+        hidapi = ctypes.cdll.LoadLibrary('libhidapi-hidraw.so.0')
     except OSError:
         try:
-            hidapi = ctypes.cdll.LoadLibrary('libhidapi-iohidmanager.so')
+            hidapi = ctypes.cdll.LoadLibrary('libhidapi-libusb.so')
         except OSError:
-                hidapi = ctypes.windll.LoadLibrary('')
+            try:
+                hidapi = ctypes.cdll.LoadLibrary('libhidapi-libusb.so.0')
+            except OSError:
+                try:
+                    hidapi = ctypes.cdll.LoadLibrary('libhidapi-iohidmanager.so')
+                except OSError:
+                    try:
+                        hidapi = ctypes.cdll.LoadLibrary('libhidapi-iohidmanager.so.0')
+                    except OSError:
+                            hidapi = ctypes.windll.LoadLibrary('')
 
 hidapi.hid_init()
 atexit.register(hidapi.hid_exit)


### PR DESCRIPTION
Hi,
some distros use .so.0 for their libs, for example Fedora22 which I'm using here.
I know this is not the most beautiful way to solve it, but it works now.

First ever pull request for me, I hope I'm doing it right.
Cheers,
lachmoewe