### PR TITLE
Copy README.md to README to fix pypi packaging.

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,23 @@
+# pyhidapi Installation
+To install pyhidapi, use the standard module install procedure: `python setup.py install`.  You also need to ensure that you have the required hidapi shared library.  On Linux distributions, this is generally in the repositories (for instance, under Debian you can install either libhidapi-hidraw0 or libhidapi-libusb0 depending on which backend you want to use).
+
+**TODO** I don't know the installation procedure for Windows or other Linux distributions.  If there is anything special needed, please add docs for it here.
+
+# OSX Support
+pyhidapi works on OSX, but requires that you first build a shared library.  There may be better ways to do this, but what I did was as follows:
+
+1. Download the latest hidapi release from https://github.com/signal11/hidapi/downloads and unzip
+2. Navigate to the mac directory
+3. Modify the Makefile to include -fPIC on the CFLAGS line.  My CFLAGS now look like this: `CFLAGS+=-I../hidapi -Wall -g -c -fPIC`
+4. Run `make`.  You should now have a hid.o file in this directory.
+5. Create the shared library by running: `gcc -shared -o libhidapi-iohidmanager.so hid.o -framework IOKit -framework CoreFoundation`
+6. Copy the resulting libhidapi-iohidmanager.so to /usr/local/lib (or somewhere in the libs search path)
+7. Install pyhidapi as normal: `python setup.py install`
+8. Verify by running python interactively and typing the following lines:
+```
+import hid
+hid.enumerate()
+```
+You should see a list of all USB hid devices on your system.
+
+That's it!


### PR DESCRIPTION
The README.md file is not included in the package that is uploaded to pypi, this results in the following error when trying to pip install hid

```
Downloading/unpacking hid (from pyqlight)
  Downloading hid-0.1.0.tar.gz
  Running setup.py (path:/tmp/pip-build-Xro90T/hid/setup.py) egg_info for package hid
    Traceback (most recent call last):
      File "<string>", line 17, in <module>
      File "/tmp/pip-build-Xro90T/hid/setup.py", line 5, in <module>
        README = open(os.path.join(here, 'README.md')).read()
    IOError: [Errno 2] No such file or directory: '/tmp/pip-build-Xro90T/hid/README.md'
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 17, in <module>

  File "/tmp/pip-build-Xro90T/hid/setup.py", line 5, in <module>

    README = open(os.path.join(here, 'README.md')).read()

IOError: [Errno 2] No such file or directory: '/tmp/pip-build-Xro90T/hid/README.md'
```

If you git clone the repository, python setup.py install works fine.

The easiest way to fix this would be to just copy README.md to README and then re-package the file as README is included by default in the generated file.
