### PR TITLE
Python 3 support

### DIFF
--- a/hid/__init__.py
+++ b/hid/__init__.py
@@ -21,7 +21,10 @@ for lib in library_paths:
     except OSError:
         pass
 else:
-    hidapi = ctypes.windll.LoadLibrary('hidapi.dll')
+    try:
+        hidapi = ctypes.windll.LoadLibrary('hidapi.dll')
+    except AttributeError:
+        raise ImportError("Unable to load the HIDAPI library")
 
 
 hidapi.hid_init()

--- a/hid/__init__.py
+++ b/hid/__init__.py
@@ -80,19 +80,15 @@ def enumerate(vid=0, pid=0):
 class Device(object):
     def __init__(self, vid=None, pid=None, serial=None, path=None):
         if path:
-            print('opening with path')
             self.__dev = hidapi.hid_open_path(path)
         elif serial:
-            print('opening with serial')
             serial = ctypes.create_unicode_buffer(serial)
             self.__dev = hidapi.hid_open(vid, pid, serial)
         elif vid and pid:
-            print('opening with vid/pid')
             self.__dev = hidapi.hid_open(vid, pid, None)
         else:
             raise ValueError('specify vid/pid or path')
 
-        print(self.__dev)
         if self.__dev == 0:
             raise HIDException('unable to open device')
 

--- a/hid/__init__.py
+++ b/hid/__init__.py
@@ -77,19 +77,19 @@ def enumerate(vid=0, pid=0):
 class Device(object):
     def __init__(self, vid=None, pid=None, serial=None, path=None):
         if path:
-            print 'opening with path'
+            print('opening with path')
             self.__dev = hidapi.hid_open_path(path)
         elif serial:
-            print 'opening with serial'
+            print('opening with serial')
             serial = ctypes.create_unicode_buffer(serial)
             self.__dev = hidapi.hid_open(vid, pid, serial)
         elif vid and pid:
-            print 'opening with vid/pid'
+            print('opening with vid/pid')
             self.__dev = hidapi.hid_open(vid, pid, None)
         else:
             raise ValueError('specify vid/pid or path')
 
-        print self.__dev
+        print(self.__dev)
         if self.__dev == 0:
             raise HIDException('unable to open device')
 


### PR DESCRIPTION
Not much needed to change, just added parentheses to the print statements for python 3 to be happy.

I also wrapped up the failed `ctypes.windll.LoadLibrary` to raise a ImportError instead, since on Linux, it raises an unhelpful AttributeError when HIDAPI isn't installed on the system.