### PR TITLE
Improve import errors

### DIFF
--- a/hid/__init__.py
+++ b/hid/__init__.py
@@ -1,3 +1,4 @@
+import os
 import ctypes
 import atexit
 
@@ -11,7 +12,8 @@ library_paths = (
     'libhidapi-libusb.so',
     'libhidapi-libusb.so.0',
     'libhidapi-iohidmanager.so',
-    'libhidapi-iohidmanager.so.0'
+    'libhidapi-iohidmanager.so.0',
+    'hidapi.dll'
 )
 
 for lib in library_paths:
@@ -21,10 +23,9 @@ for lib in library_paths:
     except OSError:
         pass
 else:
-    try:
-        hidapi = ctypes.windll.LoadLibrary('hidapi.dll')
-    except AttributeError:
-        raise ImportError("Unable to load the HIDAPI library")
+    error = "Unable to load any of the following libraries:{}"\
+        .format(' '.join(library_paths))
+    raise ImportError(error)
 
 
 hidapi.hid_init()


### PR DESCRIPTION
Hello, apmorton!

Recently I tried to `import hid` library version 0.1.1, installed with pip.   
The problem is that in docker container with ubuntu, trying to import it in the code raises following exception: `hidapi = ctypes.windll.LoadLibrary('hidapi.dll') AttributeError: 'module' object has no attribute 'windll'`

After digging I have found that the problem was missing libraries.  
If anyone will ever happen to encounter this bug again, missing libraries can be installed in Ubuntu with `sudo apt-get install libhidapi-hidraw0 libusb-1.0-0.dev libudev-dev -y`

Anyway, I still think that exception can be much clearer about this, by listing library names it was trying to find.