### PR TITLE
Add MacOS hidapi shared object to library_path

### DIFF
--- a/hid/__init__.py
+++ b/hid/__init__.py
@@ -11,7 +11,8 @@ library_paths = (
     'libhidapi-libusb.so',
     'libhidapi-libusb.so.0',
     'libhidapi-iohidmanager.so',
-    'libhidapi-iohidmanager.so.0'
+    'libhidapi-iohidmanager.so.0',
+    'libhidapi.dylib',
 )
 
 for lib in library_paths:


### PR DESCRIPTION
MacOS 10.13.6
Python 3.7.0

After installing Signal 11 hidapi (via brew), adding 'libhidapi.dyn' to **library_paths** allows pyhidapi to successfully find the shared object.

This should solve the issue discussed in the README with regard to compiling the shared object by hand. 