### PR TITLE
Python 3 support in get_feature_report

### DIFF
--- a/hid/__init__.py
+++ b/hid/__init__.py
@@ -132,7 +132,7 @@ class Device(object):
         data = ctypes.create_string_buffer(size)
 
         # Pass the id of the report to be read.
-        data[0] = chr(report_id)
+        data[0] = bytearray((report_id,))
 
         size = self.__hidcall(
             hidapi.hid_get_feature_report, self.__dev, data, size)


### PR DESCRIPTION
Elements of ctypes string buffer are of type str in Python 2 and bytes
in Python 3. Function chr() returns str in both versions and assignment
fails in Python 3. Using bytearray works in both Python 2 and Python 3.

Signed-off-by: Kubicz, Filip <filip.kubicz@nordicsemi.no>