### PR TITLE
Fix handling of missing or disconnected devices

### DIFF
--- a/hid/__init__.py
+++ b/hid/__init__.py
@@ -126,11 +126,11 @@ class Device(object):
         else:
             raise ValueError('specify vid/pid or path')
 
-        if self.__dev == 0:
+        if not self.__dev:
             raise HIDException('unable to open device')
 
     def __hidcall(self, function, *args, **kwargs):
-        if self.__dev == 0:
+        if not self.__dev:
             raise HIDException('device closed')
 
         ret = function(*args, **kwargs)

--- a/hid/__init__.py
+++ b/hid/__init__.py
@@ -174,7 +174,7 @@ class Device(object):
         return data.raw[:size]
 
     def close(self):
-        if self.__dev != 0:
+        if not self.__dev:
             hidapi.hid_close(self.__dev)
             self.__dev = 0
 

--- a/hid/__init__.py
+++ b/hid/__init__.py
@@ -176,7 +176,7 @@ class Device(object):
     def close(self):
         if not self.__dev:
             hidapi.hid_close(self.__dev)
-            self.__dev = 0
+            self.__dev = None
 
     @property
     def nonblocking(self):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(here, 'README.md')).read()
 
 
-version = '1.0.1'
+version = '1.0.2'
 
 setup(
     name='hid',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(here, 'README.md')).read()
 
 
-version = '1.0.2'
+version = '1.0.1'
 
 setup(
     name='hid',


### PR DESCRIPTION
Previous tests for 'self.__dev == 0' failed because the underlying
hid api returns None rather than 0.  After that, any operation on
the hid device would cause a segfault due to NULL dereference.