### PR TITLE
Fix check in Device.close()

### DIFF
--- a/hid/__init__.py
+++ b/hid/__init__.py
@@ -174,7 +174,7 @@ class Device(object):
         return data.raw[:size]
 
     def close(self):
-        if not self.__dev:
+        if self.__dev:
             hidapi.hid_close(self.__dev)
             self.__dev = None
 


### PR DESCRIPTION
The check condition introduced in e85ce8a should be inverted.