### PR TITLE
README: point to libusb/hidapi repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ pip install hid
 
 You also need to ensure that you have the required hidapi shared library. On Linux distributions, this is generally in the repositories (for instance, under Debian/Ubuntu/Linux Mint you can install either libhidapi-hidraw0 or libhidapi-libusb0 depending on which backend you want to use).
 
-**TODO** I don't know the installation procedure for Windows or other Linux distributions.  If there is anything special needed, please add docs for it here.
+Installation procedure for Windows is described in https://github.com/libusb/hidapi#building-on-windows
 
 # OSX Support
-pyhidapi works on OSX, but requires that you first build a shared library.  There may be better ways to do this, but what I did was as follows:
+pyhidapi works on OSX, but requires that you first build a shared library. There may be better ways to do this, but what I did was as follows:
 
-1. Download the latest hidapi release from https://github.com/signal11/hidapi/downloads and unzip
+1. Download the latest hidapi release from https://github.com/libusb/hidapi/downloads and unzip
 2. Navigate to the mac directory
 3. Modify the Makefile to include -fPIC on the CFLAGS line.  My CFLAGS now look like this: `CFLAGS+=-I../hidapi -Wall -g -c -fPIC`
 4. Run `make`.  You should now have a hid.o file in this directory.


### PR DESCRIPTION
HIDAPI has been moved to libusb/hidapi and is again maintained.
Updated the links to the new repository.

Signed-off-by: Kubicz, Filip <Filip.Kubicz@nordicsemi.no>