### PR TITLE
Device class can be used as context manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,20 @@ brew install hidapi
 ```
 It should be noted that at this time, brew still uses the old signal11 repository which has long since been abandond.
 See [Homebrew/homebrew-core#41122](https://github.com/Homebrew/homebrew-core/pull/41122).
+
+# Sample usage code
+
+The details about a HID device can be printed with following code:
+
+```python
+import hid
+
+vid = 0x046d	# Change it for your device
+pid = 0xc534	# Change it for your device
+
+with hid.Device(vid, pid) as h:
+	print(f'Device manufacturer: {h.manufacturer}')
+	print(f'Product: {h.product}')
+	print(f'Serial Number: {h.serial}')
+```
+

--- a/hid/__init__.py
+++ b/hid/__init__.py
@@ -134,8 +134,6 @@ class Device(object):
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
         self.close()
-        if exc_type:
-            return False
 
     def __hidcall(self, function, *args, **kwargs):
         if not self.__dev:

--- a/hid/__init__.py
+++ b/hid/__init__.py
@@ -135,7 +135,7 @@ class Device(object):
     def __exit__(self, exc_type, exc_value, exc_traceback):
         self.close()
         if exc_type:
-            raise exc_type(exc_value)
+            return False
 
     def __hidcall(self, function, *args, **kwargs):
         if not self.__dev:

--- a/hid/__init__.py
+++ b/hid/__init__.py
@@ -129,6 +129,14 @@ class Device(object):
         if not self.__dev:
             raise HIDException('unable to open device')
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.close()
+        if exc_type:
+            raise exc_type(exc_value)
+
     def __hidcall(self, function, *args, **kwargs):
         if not self.__dev:
             raise HIDException('device closed')


### PR DESCRIPTION
HID device need to be closed after opening them. A perfect use case for context manager.

A sample code is added in README.md for using Device() as context manager.