### PR TITLE
Python 2 support in get_feature_report

### DIFF
--- a/hid/__init__.py
+++ b/hid/__init__.py
@@ -173,7 +173,7 @@ class Device(object):
         data = ctypes.create_string_buffer(size)
 
         # Pass the id of the report to be read.
-        data[0] = bytearray((report_id,))
+        data[0] = bytes(bytearray((report_id,)))
 
         size = self.__hidcall(
             hidapi.hid_get_feature_report, self.__dev, data, size)


### PR DESCRIPTION
As far as I could test, current code does not work with Python 2.
I have tested Windows x86-64 build of Python2.6 and Python2.7 and Linux x86-64 build of Python 2.7 .
Using bytes along with bytearray works in both Python 2 and Python 3.

cf. https://github.com/apmorton/pyhidapi/pull/21