### PR TITLE
Include LICENSE in pypi packages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.md
+include LICENSE


### PR DESCRIPTION
The license text is missing from the PyPi package. Add the file to the
manifest so it gets included.