### PR TITLE
added path for hidapi.dll for windows

### DIFF
--- a/hid/__init__.py
+++ b/hid/__init__.py
@@ -15,7 +15,9 @@ library_paths = (
     'libhidapi-iohidmanager.so.0',
     'libhidapi.dylib',
     'hidapi.dll',
-    'libhidapi-0.dll'
+    'libhidapi-0.dll',
+    '..\\hidapi.dll',       
+    '.\\hidapi.dll'         # for windows. if lib is in same folder.
 )
 
 for lib in library_paths:


### PR DESCRIPTION
I love this lib, but when I distributed my python-usb-hid script, some users can't execute it.

This added paths helped, if the pyhidapi is not installed, but a copy is distributed with the script, and the dll is also only copied in to the folder of script or lib.