### PR TITLE
Allow pid to be set to 0 in Device object

### DIFF
--- a/hid/__init__.py
+++ b/hid/__init__.py
@@ -165,7 +165,7 @@ class Device(object):
         elif serial:
             serial = ctypes.create_unicode_buffer(serial)
             self.__dev = hidapi.hid_open(vid, pid, serial)
-        elif vid and pid:
+        elif vid and pid is not None:
             self.__dev = hidapi.hid_open(vid, pid, None)
         else:
             raise ValueError('specify vid/pid or path')


### PR DESCRIPTION
Initialising the `Device` object with `pid` 0 raises an error:
`ValueError('specify vid/pid or path')`

However it is possible for devices to have pid 0.
In my case I had built a [cheapino](https://github.com/tompi/cheapino) which I was trying to communicate with but couldn't do so.