### PR TITLE
Update library_paths for hidapi on FreeBSD

### DIFF
--- a/hid/__init__.py
+++ b/hid/__init__.py
@@ -8,6 +8,7 @@ __all__ = ['HIDException', 'DeviceInfo', 'Device', 'enumerate', 'BusType']
 
 hidapi = None
 library_paths = (
+    'libhidapi.so',
     'libhidapi-hidraw.so',
     'libhidapi-hidraw.so.0',
     'libhidapi-libusb.so',


### PR DESCRIPTION
comms/hidapi installs libhidapi.so on FreeBSD.

Reference:	https://github.com/freebsd/freebsd-ports/blob/main/comms/hidapi/pkg-plist